### PR TITLE
add start to scripts and use env var for bucketname

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ async function main() {
     const clusterConnStr = process.env.NODE_COUCHBASE_CONNECTION_STRING;
     const username = process.env.NODE_COUCHBASE_USERNAME;
     const password = process.env.NODE_COUCHBASE_PASSWORD;
-    const bucketName = 'travel-sample'
+    const bucketName = process.env.COUCHBASE_DEFAULT_BUCKET
 
     const cluster = await couchbase.connect(clusterConnStr, {
         username: username,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Couchbase Node.js Starter Kit",
   "main": "index.js",
   "scripts": {
-    "test": "test"
+    "test": "test",
+    "start": "node index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Replaced hardcoded bucket name 'travel-sample' with COUCHBASE_DEFAULT_BUCKET environment variable in index.js.
- Added a "start" script in package.json for easier app startup with npm start and to conform with the README instructions.